### PR TITLE
Updated versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,29 +1,6 @@
 buildscript {
 	repositories {
-		//mavenLocal()
-		mavenCentral {
-			content {
-				includeGroupByRegex "org\\.jetbrains\\..*"
-				includeGroup "org.jetbrains"
-				includeGroup "com.google.code.gson"
-				includeGroup "com.google.code.findbugs"
-				includeGroup "com.google.errorprone"
-				includeGroup "com.google.j2objc"
-				includeGroup "com.google.guava"
-				includeGroup "de.undercouch"
-				includeGroup "com.github.gundy"
-				includeGroup "org.antlr"
-				includeGroup "org.checkerframework"
-				includeGroup "net.java.dev.jna"
-				includeGroup "com.squareup.okio"
-				includeGroup "com.github.ben-manes.caffeine"
-				includeGroup "com.squareup.moshi"
-				includeGroup "com.autonomousapps"
-				includeGroup "dev.zacsweers.moshix"
-				// required by jitpack
-				includeGroup "org.sonatype.oss"
-			}
-		}
+		mavenCentral()
 	}
 	dependencies {
 		classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
@@ -61,7 +38,6 @@ subprojects {
 	version = '1.0.0-SNAPSHOT'
 
 	repositories {
-		//mavenLocal()
 		mavenCentral {
 			content {
 				includeGroupByRegex "com\\.badlogicgames\\..*"

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,12 +3,12 @@ org.gradle.jvmargs=-Xms512M -Xmx4G -XX:MaxMetaspaceSize=1G
 org.gradle.configureondemand=false
 ##
 # https://kotlinlang.org/releases.html
-kotlinVersion=1.6.20
+kotlinVersion=1.7.10
 # https://github.com/libgdx/libgdx/releases
-gdxVersion=1.10.1-SNAPSHOT
+gdxVersion=1.11.0
 lwjglVersion=3.3.1
 # https://github.com/libgdx/gdx-controllers/releases
-gdxControllersVersion=2.2.1
+gdxControllersVersion=2.2.2
 ## UI
 # https://github.com/kotcrab/vis-ui/releases
 visUiVersion=1.5.0
@@ -19,9 +19,9 @@ slf4jVersion=1.7.36
 logbackVersion=1.2.11
 ## Testing
 # https://search.maven.org/artifact/org.junit.jupiter/junit-jupiter
-junit5Version=5.8.2
+junit5Version=5.9.0
 # https://search.maven.org/artifact/io.mockk/mockk
-mockkVersion=1.12.3
+mockkVersion=1.12.5
 ## Packing/Compression
 # https://search.maven.org/artifact/org.tukaani/xz
 xzVersion=1.9
@@ -33,7 +33,7 @@ deltaDiffVersion=1.1.3
 packrVersion=3.0.3
 ## Code quality
 # https://search.maven.org/artifact/io.gitlab.arturbosch.detekt/detekt-gradle-plugin
-detektVersion=1.19.0
+detektVersion=1.21.0
 ## Dependency checking
 # https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/releases
-dependencyAnalysis=1.0.0-rc06
+dependencyAnalysis=1.12.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip


### PR DESCRIPTION
* gradle 7.4.2 -> 7.5
* kotlin 1.6.20 -> 1.7.10
* libgdx 1.10.1-SNAPSHOT -> 1.11.0
* gdxControllers 2.2.1 -> 2.2.2
* junit 5.8.2 -> 5.9.0
* mockk 1.12.3 -> 1.12.5
* detekt 1.19.0 -> 1.21.0
* da 1.0.0-rc06 -> 1.12.0

Removed content checks for mavenCentral, as this is the default trusted one.